### PR TITLE
Fix Warning: Calling plist_options is deprecated

### DIFF
--- a/Formula/ssh2iterm2.rb
+++ b/Formula/ssh2iterm2.rb
@@ -27,28 +27,8 @@ class Ssh2iterm2 < Formula
     end
   end
 
-  plist_options startup: false
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>Label</key>
-    <string>#{plist_name}</string>
-    <key>ProgramArguments</key>
-    <array>
-      <string>#{opt_bin}/ssh2iterm2</string>
-      <string>watch</string>
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>KeepAlive</key>
-    <true/>
-  </dict>
-</plist>
-
-    EOS
+  service do
+    run [opt_bin/"ssh2iterm2", "watch"]
+    keep_alive true
   end
 end


### PR DESCRIPTION
After upgrading Homebrew to 4.0 this commit should solve the regular

Warning: Calling plist_options is deprecated! Use service.require_root instead.